### PR TITLE
Fix cross-validation wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ This formulation from:
 ### Evaluation Strategy 📊
 
 We split the data into:
-- **90%** for on cross-validation
-- **10%** for hyperparameter fine tuning  
+- **90%** for cross-validation
+- **10%** for hyperparameter fine tuning
 
 Then use five-fold cross-validation on the main split (72% training, 18% testing per fold). We monitor metrics like **RMSE**, **ROC/AUROC**, **BEDROC**, and **PR Curve/AUPRC**. Also, negative sampling (5 negatives per positive) is used to mirror the real-life imbalance in biology.
 


### PR DESCRIPTION
## Summary
- fix README line about data split by removing superfluous word

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685977f33f688328bedcd69532f65e5b