### PR TITLE
Fix dataloader docstring

### DIFF
--- a/genepriority/preprocessing/dataloader.py
+++ b/genepriority/preprocessing/dataloader.py
@@ -165,7 +165,6 @@ class DataLoader:
 
         Args:
             matrix (sp.csr_matrix): Sparse matrix to log statistics for.
-            dataset_name (str): The name of the dataset being processed.
         """
         self.logger.debug(
             "Number of 0s in OMIM: %s",


### PR DESCRIPTION
## Summary
- fix `_log_matrix_stats` docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6859783a42f88328ba37aa83ee275472